### PR TITLE
PAT-193 - add tag filter to cc-install job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,10 @@ workflows:
   version: 2
   test-build:
     jobs:
-      - cc-install
+      - cc-install:
+          filters:
+            tags:
+              only: /.*/
       - test:
           filters:
             tags:


### PR DESCRIPTION
This fixes CircleCI build-on-tag functionality.
CircleCI needs the tag filter on each stage of a workflow in order for tag-filtering to work.